### PR TITLE
add support for REQ-VIDEO-LAYOUT in #EXTINF attributes

### DIFF
--- a/lib/ex_m3u8/tags/key.ex
+++ b/lib/ex_m3u8/tags/key.ex
@@ -1,13 +1,11 @@
 defmodule ExM3U8.Tags.Key do
   @moduledoc """
-  Structure representing a key tag. 
+  Structure representing a key tag.
   """
   @behaviour ExM3U8.Deserializer.AttributesDeserializer
 
   use TypedStruct
   use ExM3U8.DSL, disable_loaders: [:int, :float, :boolean]
-
-  use TypedStruct
 
   alias ExM3U8.Deserializer.AttributesDeserializer
 

--- a/lib/ex_m3u8/tags/segment.ex
+++ b/lib/ex_m3u8/tags/segment.ex
@@ -3,15 +3,21 @@ defmodule ExM3U8.Tags.Segment do
   Structure representing a media segment.
   """
   use TypedStruct
+  use ExM3U8.DSL, disable_loaders: [:int, :float, :boolean]
 
-  typedstruct enforce: true do
+  typedstruct enforce: false do
     field :duration, float()
     field :uri, String.t()
+    field :video_layout, String.t() | nil
   end
 
   defimpl ExM3U8.Serializer do
+    use ExM3U8.DSL
+    require ExM3U8.Helpers
+    alias ExM3U8.Helpers
+
     @impl true
-    def serialize(%@for{duration: duration, uri: uri}) do
+    def serialize(%@for{duration: duration, uri: uri, video_layout: video_layout}) do
       duration =
         if is_float(duration) do
           Float.ceil(duration, 3)
@@ -19,7 +25,16 @@ defmodule ExM3U8.Tags.Segment do
           duration
         end
 
-      ["#EXTINF:#{duration},\n", uri]
+      if video_layout do
+        ["#EXTINF:#{duration},REQ-VIDEO-LAYOUT=#{Helpers.quoted_string(video_layout)}\n", uri]
+      else
+        ["#EXTINF:#{duration},\n", uri]
+      end
     end
+
+    dump_attribute :video_layout,
+      attribute: "REQ-VIDEO-LAYOUT",
+      quoted_string?: true,
+      skip_empty?: false
   end
 end

--- a/test/ex_m3u8/media_playlist_test.exs
+++ b/test/ex_m3u8/media_playlist_test.exs
@@ -246,6 +246,23 @@ defmodule ExM3U8.MediaPlaylistTest do
     assert playlist.timeline == timeline
   end
 
+  test "deserialize segments with video layout attribute" do
+    manifest = """
+    #EXTM3U
+    #EXT-X-VERSION:12
+    #EXT-X-TARGETDURATION:6
+    #EXT-X-PART-INF:PART-TARGET=1.0
+    #EXTINF:3.0,REQ-VIDEO-LAYOUT="CH-STEREO"
+    segment1.m4s
+    """
+
+    assert {:ok, playlist} = ExM3U8.Deserializer.Parser.parse_media_playlist(manifest)
+
+    assert playlist.timeline == [
+             %ExM3U8.Tags.Segment{uri: "segment1.m4s", duration: 3.0, video_layout: "CH-STEREO"}
+           ]
+  end
+
   defmodule CustomTag do
     @moduledoc false
 

--- a/test/ex_m3u8/tags/segment_test.exs
+++ b/test/ex_m3u8/tags/segment_test.exs
@@ -15,4 +15,18 @@ defmodule ExM3U8.Tags.SegmentTest do
            """
            |> String.trim_trailing() == serialize(segment)
   end
+
+  test "serialize segment with video layout" do
+    segment = %ExM3U8.Tags.Segment{
+      duration: 6.555,
+      uri: "segment.m4s",
+      video_layout: "CH-STEREO"
+    }
+
+    assert """
+           #EXTINF:6.555,REQ-VIDEO-LAYOUT="CH-STEREO"
+           segment.m4s
+           """
+           |> String.trim_trailing() == serialize(segment)
+  end
 end


### PR DESCRIPTION
This pull request introduces support for the MV-HEVC REQ-VIDEO-LAYOUT attribute in #EXTINF tags within m3u8 files. The REQ-VIDEO-LAYOUT attribute is a new addition to the MV-HEVC specification, allowing for the specification of required video layouts for multi-view video streams. This enhancement enables ex_m3u8 to parse and handle m3u8 playlists that include this attribute, ensuring compatibility with the latest MV-HEVC standards.

### Changes

- Added parsing for the REQ-VIDEO-LAYOUT attribute in #EXTINF tags.
- Updated the Segment struct to include a field for `video_layout`.
- Added tests to verify the correct parsing of REQ-VIDEO-LAYOUT.

### Benefits:

- Ensures compatibility with the latest MV-HEVC standards.
- Allows users of ex_m3u8 to work with m3u8 files that include the REQ-VIDEO-LAYOUT attribute, enabling more advanced video streaming scenarios.

Feedback appreciated!