### PR TITLE
Add support for REQ-VIDEO-LAYOUT in EXT-STREAM-INF attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `ex_m3u8` into your list of dependencies 
 ```elixir
 def deps do
   [
-    {:ex_m3u8, "~> 0.11.0"}
+    {:ex_m3u8, "~> 0.12.0"}
   ]
 end
 ```

--- a/lib/ex_m3u8/deserializer/parser.ex
+++ b/lib/ex_m3u8/deserializer/parser.ex
@@ -34,7 +34,7 @@ defmodule ExM3U8.Deserializer.Parser do
   defp assemble_multi_variant_playlist(tags) do
     items =
       tags
-      |> Enum.filter(fn {tag, _item} -> tag in [:stream, :content_steering] end)
+      |> Enum.filter(fn {tag, _item} -> tag in [:stream, :content_steering, :media] end)
       |> Enum.map(fn {_tag, item} -> item end)
 
     {:version, version} =

--- a/lib/ex_m3u8/tags/media.ex
+++ b/lib/ex_m3u8/tags/media.ex
@@ -1,6 +1,6 @@
 defmodule ExM3U8.Tags.Media do
   @moduledoc """
-  Structure representing a media tag. 
+  Structure representing a media tag.
   """
   @behaviour ExM3U8.Deserializer.AttributesDeserializer
 
@@ -17,6 +17,7 @@ defmodule ExM3U8.Tags.Media do
     field :name, String.t()
     field :default?, boolean(), default: false
     field :auto_select?, boolean(), default: false
+    field :channels, String.t() | nil, default: nil
   end
 
   @impl true
@@ -54,6 +55,10 @@ defmodule ExM3U8.Tags.Media do
     default: false,
     allow_empty?: true,
     type: :boolean
+
+  load_attribute :channels,
+    attribute: "CHANNELS",
+    allow_empty?: true
 
   defp load(:type, attrs) do
     case Map.get(attrs, "TYPE", nil) do
@@ -95,7 +100,8 @@ defmodule ExM3U8.Tags.Media do
         :language,
         :name,
         :default?,
-        :auto_select?
+        :auto_select?,
+        :channels
       ])
     end
 
@@ -140,5 +146,10 @@ defmodule ExM3U8.Tags.Media do
     dump_attribute :auto_select?,
       attribute: "AUTOSELECT",
       empty_arg: false
+
+    dump_attribute :channels,
+      attribute: "CHANNELS",
+      quoted_string?: true,
+      skip_empty?: true
   end
 end

--- a/lib/ex_m3u8/tags/stream.ex
+++ b/lib/ex_m3u8/tags/stream.ex
@@ -24,6 +24,7 @@ defmodule ExM3U8.Tags.Stream do
     field :subtitles, String.t() | nil, default: nil
     field :uri, String.t() | nil, default: nil
     field :pathway_id, String.t() | nil, default: nil
+    field :video_layout, String.t() | nil, default: nil
   end
 
   @impl true
@@ -72,6 +73,10 @@ defmodule ExM3U8.Tags.Stream do
 
   load_attribute :pathway_id,
     attribute: "PATHWAY-ID",
+    allow_empty?: true
+
+  load_attribute :video_layout,
+    attribute: "REQ-VIDEO-LAYOUT",
     allow_empty?: true
 
   # NOTE: uri is a part of tag's new line, we don't load it from attributes
@@ -124,6 +129,7 @@ defmodule ExM3U8.Tags.Stream do
         :video,
         :subtitles,
         :pathway_id,
+        :video_layout,
         :uri
       ])
     end
@@ -162,9 +168,13 @@ defmodule ExM3U8.Tags.Stream do
       attribute: "PATHWAY-ID",
       quoted_string?: true
 
+    dump_attribute :video_layout,
+      attribute: "REQ-VIDEO-LAYOUT",
+      quoted_string?: true
+
     ignore_dump(:uri)
 
-    # resolution by hand as the value is not that easy 
+    # resolution by hand as the value is not that easy
     # to process
     defp dump({:resolution, nil}), do: []
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExM3U8.MixProject do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.12.0"
   @github_url "https://github.com/membraneframework/ex_m3u8"
 
   def project do

--- a/test/ex_m3u8/multivariant_playlist_test.exs
+++ b/test/ex_m3u8/multivariant_playlist_test.exs
@@ -3,40 +3,63 @@ defmodule ExM3U8.MultivariantPlaylistTest do
 
   import ExM3U8.TestUtils
 
-  alias ExM3U8.Tags.{ContentSteering, Stream}
+  alias ExM3U8.Tags.{ContentSteering, Media, Stream}
 
   test "deserialize multivariant manifest" do
     manfiest = """
     #EXTM3U
-    #EXT-X-VERSION:7
+    #EXT-X-VERSION:12
     #EXT-X-INDEPENDENT-SEGMENTS
     #EXT-X-CONTENT-STEERING:SERVER-URI="http://example.com/content-steering",PATHWAY-ID="CDN-A"
-    #EXT-X-STREAM-INF:BANDWIDTH=150000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2"
+    #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="atmos-48-448",NAME="English",LANGUAGE="en-US",AUTOSELECT=YES,DEFAULT=YES,CHANNELS="16/JOC",URI="ec3-atmos-48khz-448kbps-en_audio/prog_index.m3u8"
+    #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="ac3-48-384",NAME="English",LANGUAGE="en-US",AUTOSELECT=YES,DEFAULT=YES,CHANNELS="6",URI="ac3-5.1-48khz-384kbps-en_audio/prog_index.m3u8"
+    #EXT-X-STREAM-INF:BANDWIDTH=150000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2",REQ-VIDEO-LAYOUT="CH-MONO"
     http://example.com/low/index.m3u8
-    #EXT-X-STREAM-INF:BANDWIDTH=240000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2"
+    #EXT-X-STREAM-INF:BANDWIDTH=240000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2",REQ-VIDEO-LAYOUT="CH-MONO"
     http://example.com/lo_mid/index.m3u8
-    #EXT-X-STREAM-INF:BANDWIDTH=440000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2"
+    #EXT-X-STREAM-INF:BANDWIDTH=440000,RESOLUTION=416x234,CODECS="avc1.42e00a,mp4a.40.2",REQ-VIDEO-LAYOUT="CH-MONO"
     http://example.com/hi_mid/index.m3u8
-    #EXT-X-STREAM-INF:BANDWIDTH=640000,RESOLUTION=640x360,CODECS="avc1.42e00a,mp4a.40.2"
+    #EXT-X-STREAM-INF:BANDWIDTH=640000,RESOLUTION=640x360,CODECS="avc1.42e00a,mp4a.40.2",REQ-VIDEO-LAYOUT="CH-MONO"
     http://example.com/high/index.m3u8
-    #EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.5"
+    #EXT-X-STREAM-INF:BANDWIDTH=64000,CODECS="mp4a.40.5",REQ-VIDEO-LAYOUT="CH-MONO"
     http://example.com/audio/index.m3u8
     """
 
     assert {:ok,
             %ExM3U8.MultivariantPlaylist{
-              version: 7,
+              version: 12,
               independent_segments: true,
               items: [
                 %ContentSteering{
                   server_uri: "http://example.com/content-steering",
                   pathway_id: "CDN-A"
                 },
+                %Media{
+                  type: :audio,
+                  uri: "ec3-atmos-48khz-448kbps-en_audio/prog_index.m3u8",
+                  group_id: "atmos-48-448",
+                  language: "en-US",
+                  name: "English",
+                  default?: true,
+                  auto_select?: true,
+                  channels: "16/JOC"
+                },
+                %Media{
+                  type: :audio,
+                  uri: "ac3-5.1-48khz-384kbps-en_audio/prog_index.m3u8",
+                  group_id: "ac3-48-384",
+                  language: "en-US",
+                  name: "English",
+                  default?: true,
+                  auto_select?: true,
+                  channels: "6"
+                },
                 %Stream{
                   bandwidth: 150_000,
                   resolution: {416, 234},
                   codecs: "avc1.42e00a,mp4a.40.2",
-                  uri: "http://example.com/low/index.m3u8"
+                  uri: "http://example.com/low/index.m3u8",
+                  video_layout: "CH-MONO"
                 },
                 %Stream{
                   bandwidth: 240_000,
@@ -67,64 +90,91 @@ defmodule ExM3U8.MultivariantPlaylistTest do
 
   test "serialize multivariant manifest" do
     playlist = %ExM3U8.MultivariantPlaylist{
-      version: 7,
+      version: 12,
       independent_segments: true,
       items: [
         %ContentSteering{
           server_uri: "http://example.com/content-steering",
           pathway_id: "CDN-A"
         },
+        %Media{
+          type: :audio,
+          uri: "ec3-atmos-48khz-448kbps-en_audio/prog_index.m3u8",
+          group_id: "atmos-48-448",
+          language: "en-US",
+          name: "English",
+          default?: true,
+          auto_select?: true,
+          channels: "16/JOC"
+        },
+        %Media{
+          type: :audio,
+          uri: "ac3-5.1-48khz-384kbps-en_audio/prog_index.m3u8",
+          group_id: "ac3-48-384",
+          language: "en-US",
+          name: "English",
+          default?: true,
+          auto_select?: true,
+          channels: "6"
+        },
         %Stream{
           subtitles: "DEFAULT",
           bandwidth: 150_000,
           resolution: {416, 234},
           codecs: "avc1.42e00a,mp4a.40.2",
-          uri: "http://example.com/low/index.m3u8"
+          uri: "http://example.com/low/index.m3u8",
+          video_layout: "CH-MONO"
         },
         %Stream{
           video: "DEFAULT",
           bandwidth: 240_000,
           resolution: {416, 234},
           codecs: "avc1.42e00a,mp4a.40.2",
-          uri: "http://example.com/lo_mid/index.m3u8"
+          uri: "http://example.com/lo_mid/index.m3u8",
+          video_layout: "CH-MONO"
         },
         %Stream{
           audio: "DEFAULT",
           bandwidth: 440_000,
           resolution: {416, 234},
           codecs: "avc1.42e00a,mp4a.40.2",
-          uri: "http://example.com/hi_mid/index.m3u8"
+          uri: "http://example.com/hi_mid/index.m3u8",
+          video_layout: "CH-MONO"
         },
         %Stream{
           bandwidth: 640_000,
           resolution: {640, 360},
           frame_rate: 60.0,
           codecs: "avc1.42e00a,mp4a.40.2",
-          uri: "http://example.com/high/index.m3u8"
+          uri: "http://example.com/high/index.m3u8",
+          video_layout: "CH-MONO"
         },
         %Stream{
           bandwidth: 64_000,
           average_bandwidth: 50_000,
           codecs: "mp4a.40.5",
-          uri: "http://example.com/audio/index.m3u8"
+          uri: "http://example.com/audio/index.m3u8",
+          video_layout: "CH-MONO"
         }
       ]
     }
 
     assert """
            #EXTM3U
-           #EXT-X-VERSION:7
+           #EXT-X-VERSION:12
            #EXT-X-INDEPENDENT-SEGMENTS
            #EXT-X-CONTENT-STEERING:SERVER-URI="http://example.com/content-steering",PATHWAY-ID="CDN-A"
-           #EXT-X-STREAM-INF:BANDWIDTH=150000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,SUBTITLES="DEFAULT"
+           #EXT-X-MEDIA:TYPE=AUDIO,URI="ec3-atmos-48khz-448kbps-en_audio/prog_index.m3u8",GROUP-ID="atmos-48-448",LANGUAGE="en-US",NAME="English",DEFAULT=YES,AUTOSELECT=YES,CHANNELS="16/JOC"
+           #EXT-X-MEDIA:TYPE=AUDIO,URI="ac3-5.1-48khz-384kbps-en_audio/prog_index.m3u8",GROUP-ID="ac3-48-384",LANGUAGE="en-US",NAME="English",DEFAULT=YES,AUTOSELECT=YES,CHANNELS="6"
+           #EXT-X-STREAM-INF:BANDWIDTH=150000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,SUBTITLES="DEFAULT",REQ-VIDEO-LAYOUT="CH-MONO"
            http://example.com/low/index.m3u8
-           #EXT-X-STREAM-INF:BANDWIDTH=240000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,VIDEO="DEFAULT"
+           #EXT-X-STREAM-INF:BANDWIDTH=240000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,VIDEO="DEFAULT",REQ-VIDEO-LAYOUT="CH-MONO"
            http://example.com/lo_mid/index.m3u8
-           #EXT-X-STREAM-INF:BANDWIDTH=440000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,AUDIO="DEFAULT"
+           #EXT-X-STREAM-INF:BANDWIDTH=440000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=416x234,AUDIO="DEFAULT",REQ-VIDEO-LAYOUT="CH-MONO"
            http://example.com/hi_mid/index.m3u8
-           #EXT-X-STREAM-INF:BANDWIDTH=640000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=60.0
+           #EXT-X-STREAM-INF:BANDWIDTH=640000,CODECS="avc1.42e00a,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=60.0,REQ-VIDEO-LAYOUT="CH-MONO"
            http://example.com/high/index.m3u8
-           #EXT-X-STREAM-INF:BANDWIDTH=64000,AVERAGE-BANDWIDTH=50000,CODECS="mp4a.40.5"
+           #EXT-X-STREAM-INF:BANDWIDTH=64000,AVERAGE-BANDWIDTH=50000,CODECS="mp4a.40.5",REQ-VIDEO-LAYOUT="CH-MONO"
            http://example.com/audio/index.m3u8
            """ == serialize(playlist)
   end


### PR DESCRIPTION
This pull request replaces #4, which was misdirected.

This pull request introduces support for the MV-HEVC REQ-VIDEO-LAYOUT attribute in #EXT-X-STREAM-INF tags within multivariant m3u8 files. The REQ-VIDEO-LAYOUT attribute is a new addition to the MV-HEVC specification, allowing for the specification of required video layouts for multi-view video streams. This enhancement enables ex_m3u8 to parse and handle m3u8 playlists that include this attribute, ensuring compatibility with the latest MV-HEVC standards.

### Changes

- Added parsing for the REQ-VIDEO-LAYOUT attribute in #EXT-X-STREAM-INF tags.
- Updated the `Stream` struct to include a field for `video_layout`.
- Added tests to verify the correct parsing of REQ-VIDEO-LAYOUT.
- Includes `EXT-X-MEDIA` tags when parsing/deserializing multivariant m3u8 files
- Captures the "CHANNELS" attribute on `Media` tags

### Benefits:
- Ensures compatibility with the latest MV-HEVC standards.
- Allows users of ex_m3u8 to work with m3u8 files that include the REQ-VIDEO-LAYOUT attribute, enabling more advanced video streaming scenarios.

Feedback appreciated!