### PR TITLE
fix parsing of the #EXT-X-ENDLIST tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `ex_m3u8` into your list of dependencies 
 ```elixir
 def deps do
   [
-    {:ex_m3u8, "~> 0.12.0"}
+    {:ex_m3u8, "~> 0.13.0"}
   ]
 end
 ```

--- a/lib/ex_m3u8/deserializer/parser.ex
+++ b/lib/ex_m3u8/deserializer/parser.ex
@@ -127,8 +127,9 @@ defmodule ExM3U8.Deserializer.Parser do
 
         {:ok, struct!(ExM3U8.MediaPlaylist.Info, tags)}
 
-      {:error, _fields} ->
-        {:error, "missing required media playlist info field"}
+      {:error, fields} ->
+        description = Enum.map_join(fields, &to_string/1, ", ")
+        {:error, "missing required media playlist info field: #{description}"}
     end
   end
 
@@ -381,10 +382,10 @@ defmodule ExM3U8.Deserializer.Parser do
     end
   end
 
-  parse_tag "ENDLIST" do
+  parse_raw "#EXT-X-ENDLIST" do
     _value = value
 
-    {:ok, :end_list, true}
+    {:ok, :end_list, true, lines}
   end
 
   defp do_parse([line | lines], acc, opts) do

--- a/lib/ex_m3u8/deserializer/parser.ex
+++ b/lib/ex_m3u8/deserializer/parser.ex
@@ -128,7 +128,7 @@ defmodule ExM3U8.Deserializer.Parser do
         {:ok, struct!(ExM3U8.MediaPlaylist.Info, tags)}
 
       {:error, fields} ->
-        description = Enum.map_join(fields, &to_string/1, ", ")
+        description = Enum.map_join(fields, ", ", &to_string/1)
         {:error, "missing required media playlist info field: #{description}"}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExM3U8.MixProject do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.13.0"
   @github_url "https://github.com/membraneframework/ex_m3u8"
 
   def project do

--- a/test/ex_m3u8/media_playlist_test.exs
+++ b/test/ex_m3u8/media_playlist_test.exs
@@ -127,7 +127,7 @@ defmodule ExM3U8.MediaPlaylistTest do
            |> String.trim_trailing() == serialize(server_control)
   end
 
-  test "deserialize serer control" do
+  test "deserialize server control" do
     server_control = %ExM3U8.MediaPlaylist.ServerControl{
       can_block_reload?: true,
       part_hold_back: 3.0,
@@ -171,6 +171,7 @@ defmodule ExM3U8.MediaPlaylistTest do
     segment2.m4s
     #EXT-X-PRELOAD-HINT:TYPE=PART,URI="segment3.1.m4s"
     #EXT-X-RENDITION-REPORT:URI="rendition_uri.m3u8",LAST-MSN=5,LAST-PART=3
+    #EXT-X-ENDLIST
     """
 
     info = %ExM3U8.MediaPlaylist.Info{
@@ -185,7 +186,8 @@ defmodule ExM3U8.MediaPlaylistTest do
       start: {10.0, true},
       part_inf: 1.0,
       media_sequence: 10,
-      discontinuity_sequence: 3
+      discontinuity_sequence: 3,
+      end_list?: true
     }
 
     date = ~U[2077-12-12 12:00:00Z]
@@ -219,7 +221,7 @@ defmodule ExM3U8.MediaPlaylistTest do
       timeline: timeline
     }
 
-    assert {:ok, ^playlist} = ExM3U8.Deserializer.Parser.parse_media_playlist(manifest)
+    assert {:ok, playlist} == ExM3U8.Deserializer.Parser.parse_media_playlist(manifest)
   end
 
   test "deserialize segments with nested tags" do


### PR DESCRIPTION
Prior to this PR the deserializer used `parse_tag "ENDLIST"` to grab the `:end_list?` tag. However, the `parse_tag` macro expects tags that have a `:`. Because `#EXT-X-ENDLIST` has no `:`, `parse_tag` isn't able to correctly parse `:end_list`.

This PR fixes that by using `parse_raw "#EXT-X-ENDLIST"` instead. Tests included verify it's now working.

Feedback welcome!