### PR TITLE
handle #EXT-X-INDEPENDENT-SEGMENTS tag in media playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `ex_m3u8` into your list of dependencies 
 ```elixir
 def deps do
   [
-    {:ex_m3u8, "~> 0.12.0"}
+    {:ex_m3u8, "~> 0.14.0"}
   ]
 end
 ```

--- a/lib/ex_m3u8/deserializer/parser.ex
+++ b/lib/ex_m3u8/deserializer/parser.ex
@@ -111,6 +111,7 @@ defmodule ExM3U8.Deserializer.Parser do
              :target_duration,
              version: nil,
              playlist_type: nil,
+             independent_segments: false,
              server_control: nil,
              part_inf: nil,
              media_sequence: 0,

--- a/lib/ex_m3u8/media_playlist/info.ex
+++ b/lib/ex_m3u8/media_playlist/info.ex
@@ -6,6 +6,7 @@ defmodule ExM3U8.MediaPlaylist.Info do
 
   typedstruct enforce: true do
     field :version, pos_integer() | nil
+    field :independent_segments, boolean(), default: false
     field :playlist_type, :vod | :event | nil, default: nil
     field :target_duration, pos_integer()
     field :server_control, ExM3U8.MediaPlaylist.ServerControl.t() | nil, default: nil
@@ -33,6 +34,7 @@ defmodule ExM3U8.MediaPlaylist.Info do
       Helpers.generate_sorter(tag, [
         :version,
         :playlist_type,
+        :independent_segments,
         :target_duration,
         :server_control,
         :part_inf,
@@ -61,6 +63,10 @@ defmodule ExM3U8.MediaPlaylist.Info do
     dump_tag :target_duration,
       tag: "TARGETDURATION",
       skip_empty?: false
+
+    defp dump({:independent_segments, true}), do: [Helpers.tag_prefix(), "INDEPENDENT-SEGMENTS"]
+
+    defp dump({:independent_segments, false}), do: []
 
     defp dump({:server_control, nil}), do: []
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExM3U8.MixProject do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.14.0"
   @github_url "https://github.com/membraneframework/ex_m3u8"
 
   def project do

--- a/test/ex_m3u8/media_playlist_test.exs
+++ b/test/ex_m3u8/media_playlist_test.exs
@@ -7,6 +7,7 @@ defmodule ExM3U8.MediaPlaylistTest do
     info = %ExM3U8.MediaPlaylist.Info{
       playlist_type: :vod,
       target_duration: 6,
+      independent_segments: true,
       version: 7,
       server_control: %ExM3U8.MediaPlaylist.ServerControl{
         can_block_reload?: true,
@@ -22,6 +23,7 @@ defmodule ExM3U8.MediaPlaylistTest do
     assert """
            #EXT-X-VERSION:7
            #EXT-X-PLAYLIST-TYPE:VOD
+           #EXT-X-INDEPENDENT-SEGMENTS
            #EXT-X-TARGETDURATION:6
            #EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=3.0,HOLD-BACK=6.0,CAN-SKIP-UNTIL=12.0
            #EXT-X-PART-INF:PART-TARGET=1.0
@@ -148,6 +150,7 @@ defmodule ExM3U8.MediaPlaylistTest do
     manifest = """
     #EXTM3U
     #EXT-X-VERSION:7
+    #EXT-X-INDEPENDENT-SEGMENTS
     #EXT-X-TARGETDURATION:6
     #EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=3.0,HOLD-BACK=6.0,CAN-SKIP-UNTIL=12.0
     #EXT-X-PART-INF:PART-TARGET=1.0
@@ -176,6 +179,7 @@ defmodule ExM3U8.MediaPlaylistTest do
     info = %ExM3U8.MediaPlaylist.Info{
       target_duration: 6,
       version: 7,
+      independent_segments: true,
       server_control: %ExM3U8.MediaPlaylist.ServerControl{
         can_block_reload?: true,
         part_hold_back: 3.0,


### PR DESCRIPTION
The `#EXT-X-INDEPENDENT-SEGMENTS` tag is [valid in both media and master](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.5.1) playlists.

This PR updates the media playlist parser and serializer to account for the `:independent_segments` tag.

Feedback welcome!