### PR TITLE
Fix the issue where deserializing a segment and serializing it again leads to a different duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can be installed by adding `ex_m3u8` into your list of dependencies 
 ```elixir
 def deps do
   [
-    {:ex_m3u8, "~> 0.14.2"}
+    {:ex_m3u8, "~> 0.15.0"}
   ]
 end
 ```

--- a/lib/ex_m3u8/deserializer/attributes_deserializer.ex
+++ b/lib/ex_m3u8/deserializer/attributes_deserializer.ex
@@ -6,7 +6,7 @@ defmodule ExM3U8.Deserializer.AttributesDeserializer do
   @spec deserialize_struct_fields(module(), function(), map()) ::
           {:ok, struct()} | {:error, term()}
   def deserialize_struct_fields(module, load_fun, attrs) do
-    module.__struct__
+    module.__struct__()
     |> Map.delete(:__struct__)
     |> Map.keys()
     |> Enum.reduce_while([], fn field, loaded ->

--- a/lib/ex_m3u8/dsl.ex
+++ b/lib/ex_m3u8/dsl.ex
@@ -13,7 +13,7 @@ defmodule ExM3U8.DSL do
         import unquote(__MODULE__)
 
         defp __dump_value(value) when is_binary(value), do: value
-        defp __dump_value(value) when is_float(value), do: "#{Float.ceil(value, 3)}"
+        defp __dump_value(value) when is_float(value), do: "#{Float.round(value, 3)}"
         defp __dump_value(value) when is_integer(value), do: "#{value}"
         defp __dump_value(true), do: "YES"
         defp __dump_value(false), do: "NO"

--- a/lib/ex_m3u8/tags/segment.ex
+++ b/lib/ex_m3u8/tags/segment.ex
@@ -14,7 +14,7 @@ defmodule ExM3U8.Tags.Segment do
     def serialize(%@for{duration: duration, uri: uri}) do
       duration =
         if is_float(duration) do
-          Float.ceil(duration, 3)
+          Float.round(duration, 3)
         else
           duration
         end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExM3U8.MixProject do
   use Mix.Project
 
-  @version "0.14.2"
+  @version "0.15.0"
   @github_url "https://github.com/membraneframework/ex_m3u8"
 
   def project do

--- a/test/ex_m3u8/media_playlist_test.exs
+++ b/test/ex_m3u8/media_playlist_test.exs
@@ -146,6 +146,33 @@ defmodule ExM3U8.MediaPlaylistTest do
              ExM3U8.MediaPlaylist.ServerControl.deserialize(attrs)
   end
 
+  test "deserialize playlist with non-round EXTINF values and reserialize without losing precision" do
+    manifest = """
+    #EXTM3U
+    #EXT-X-VERSION:6
+    #EXT-X-TARGETDURATION:7
+    #EXT-X-PLAYLIST-TYPE:VOD
+    #EXT-X-MAP:URI="audio_init.mp4"
+    #EXTINF:6.016,
+    segments/audio_000000.m4s
+    #EXTINF:6.016,
+    segments/audio_000001.m4s
+    #EXTINF:6.016,
+    segments/audio_000002.m4s
+    #EXTINF:5.952,
+    segments/audio_000003.m4s
+    """
+
+    assert {:ok, playlist} = ExM3U8.Deserializer.Parser.parse_media_playlist(manifest)
+
+    # this one succeeds
+    assert Enum.at(playlist.timeline, 1).duration == 6.016
+
+    # these fail
+    assert String.contains?(serialize(playlist), "6.016")
+    refute String.contains?(serialize(playlist), "6.017")
+  end
+
   test "deserialize media playlist" do
     manifest = """
     #EXTM3U

--- a/test/ex_m3u8/media_playlist_test.exs
+++ b/test/ex_m3u8/media_playlist_test.exs
@@ -165,10 +165,8 @@ defmodule ExM3U8.MediaPlaylistTest do
 
     assert {:ok, playlist} = ExM3U8.Deserializer.Parser.parse_media_playlist(manifest)
 
-    # this one succeeds
     assert Enum.at(playlist.timeline, 1).duration == 6.016
 
-    # these fail
     assert String.contains?(serialize(playlist), "6.016")
     refute String.contains?(serialize(playlist), "6.017")
   end

--- a/test/ex_m3u8/tags/segment_test.exs
+++ b/test/ex_m3u8/tags/segment_test.exs
@@ -15,4 +15,20 @@ defmodule ExM3U8.Tags.SegmentTest do
            """
            |> String.trim_trailing() == serialize(segment)
   end
+
+  test "serialize a segment with a problematic duration value" do
+    segment = %ExM3U8.Tags.Segment{
+      duration: 6.016,
+      uri: "segment.m4s"
+    }
+
+    serialized = serialize(segment)
+
+    refute String.contains?(serialized, "6.017")
+    assert """
+           #EXTINF:6.016,
+           segment.m4s
+           """
+           |> String.trim_trailing() == serialized
+  end
 end

--- a/test/ex_m3u8/tags/segment_test.exs
+++ b/test/ex_m3u8/tags/segment_test.exs
@@ -25,6 +25,7 @@ defmodule ExM3U8.Tags.SegmentTest do
     serialized = serialize(segment)
 
     refute String.contains?(serialized, "6.017")
+
     assert """
            #EXTINF:6.016,
            segment.m4s


### PR DESCRIPTION
The test should show the case which was problematic

The other stray fix was to fix this warning when used with Elixir 1.18.1: 

```
warning: using map.field notation (without parentheses) to invoke function ExM3U8.Tags.Skip.__struct__() is deprecated, you must add parentheses instead: remote.function()
  (ex_m3u8 0.14.2) lib/ex_m3u8/deserializer/attributes_deserializer.ex:9: ExM3U8.Deserializer.AttributesDeserializer.deserialize_struct_fields/3
  test/ex_m3u8/tags/skip_test.exs:25: ExM3U8.Tags.SkipTest."test deserialize skip"/1
  (ex_unit 1.18.1) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
  (stdlib 6.0) timer.erl:590: :timer.tc/2
  (ex_unit 1.18.1) lib/ex_unit/runner.ex:433: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```